### PR TITLE
Non Even Grids

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,48 @@
 (function() {
 
   var EasyGrid = function(options) {
-
-    var req = Object.assign({
+    this.EVEN = 'even';
+    this.state = {
       x:0,
       y:0,
       columns:10,
+      columnRatio: this.EVEN,
       rows:1,
+      rowRatio: this.EVEN,
       gutterWidth: 0,
       gutterHeight: 0,
       moduleWidth:50,
-      moduleHeight:500
-    }, options);
+      moduleHeight:500,
+    };
+    this.setOptions(options)
+  }
+
+  EasyGrid.prototype.setOptions = function(options) {
+    var req = Object.assign(this.state, options);
+
+    // calculate the grid ratios
+    if(req.columnRatio === this.EVEN) req.columnRatio = new Array(req.columns).fill(1);
+    if(req.rowRatio === this.EVEN) req.rowRatio = new Array(req.rows).fill(1);
+
+    if(!req.columnRatio !== this.EVEN && req.width === 'undefined') {
+      console.log('You need to provide a width when using a non even column ratio');
+      return;
+    }
+
+    if(!req.rowRatio !== this.EVEN && req.height === 'undefined') {
+      console.log('You need to provide a height when using a non even row ratio');
+      return;
+    }
+
+    if(req.columnRatio !== this.EVEN && req.columnRatio.length !== req.columns) {
+      console.log('Your column ratio length needs to match the number of columns for non even ratios');
+      return;
+    }
+
+    if(req.rowRatio !== this.EVEN && req.rowRatio.length !== req.rows) {
+      console.log('Your row ratio length needs to match the number of row for non even ratios');
+      return;
+    }
 
     // if gutter is set, override gutterWidth and gutterHeight
     if(typeof req.gutter !== 'undefined') {
@@ -33,20 +64,38 @@
       req.height = (req.moduleHeight * req.rows) + (req.gutterHeight * (req.rows-1))
     }
 
-    // Compute the grid
     this.state = req;
-    this.modules = [];
-    for(var y = 0; y < req.rows; y++) {
-      for(var x = 0; x < req.columns; x++) {
-        this.modules.push({
-          x: req.x + (x * req.moduleWidth) + (x * req.gutterWidth),
-          y: req.y + (y * req.moduleHeight) + (y * req.gutterHeight),
-          width: req.moduleWidth,
-          height: req.moduleHeight
-        });
-      }
-    }
+    this.calculateGrid()
+  }
 
+  EasyGrid.prototype.calculateGrid = function() {
+    this.modules = [];
+    // normalize the ratios
+    var totalColumnRatio = this.state.columnRatio.reduce((acc, cur) => acc + cur);
+    var totalRowRatio = this.state.rowRatio.reduce((acc, cur) => acc + cur);
+    this.normalizedColumnRatio = this.state.columnRatio.map((item) => item / totalColumnRatio);
+    this.normalizedRowRatio = this.state.rowRatio.map((item) => item / totalRowRatio);
+
+    var totalHeight = 0;
+
+    for(var y = 0; y < this.state.rows; y++) {
+      var height = (this.state.height - ((this.state.rows-1) * this.state.gutterHeight)) * this.normalizedRowRatio[y];
+      var totalWidth = 0;
+      for(var x = 0; x < this.state.columns; x++) {
+        var width = (this.state.width - ((this.state.columns-1) * this.state.gutterWidth)) * this.normalizedColumnRatio[x];
+        
+
+        this.modules.push({
+          x: this.state.x + totalWidth + (x * this.state.gutterWidth),
+          y: this.state.y + totalHeight + (y * this.state.gutterHeight),
+          width: width,
+          height: height
+        });
+
+        totalWidth += width;
+      }
+      totalHeight += height;
+    }
   }
 
   EasyGrid.prototype.getModule = function(column, row){
@@ -62,10 +111,11 @@
   // Convenience Functions to get Colspans, Rowspans and Modulespans
   EasyGrid.prototype.colSpan = function(from, to) {
     var startCol = this.getModule(from, 1),
+        endCol = this.getModule(to, 1),
         delta = to - from,
         x = startCol.x,
         y = startCol.y,
-        w = this.state.moduleWidth + (delta * (this.state.moduleWidth + this.state.gutter)),
+        w = endCol.x + endCol.width - startCol.x,
         h = this.state.height;
 
     return {
@@ -78,11 +128,12 @@
 
   EasyGrid.prototype.rowSpan = function(from, to) {
     var startRow = this.getModule(1, from),
+        endRow = this.getModule(1, to),
         delta = to - from,
         x = startRow.x,
         y = startRow.y,
         w = this.state.width,
-        h = this.state.moduleHeight + (delta * (this.state.moduleHeight + this.state.gutter));
+        h = endRow.y + endRow.height - startRow.y;
 
     return {
       x: x,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-(function() {
-
-  var EasyGrid = function(options) {
+class EasyGrid {
+  constructor(options) {
     this.EVEN = 'even';
     this.state = {
       x:0,
@@ -17,8 +16,8 @@
     this.setOptions(options)
   }
 
-  EasyGrid.prototype.setOptions = function(options) {
-    var req = Object.assign(this.state, options);
+  setOptions(options) {
+    const req = Object.assign(this.state, options);
 
     // calculate the grid ratios
     if(req.columnRatio === this.EVEN) req.columnRatio = new Array(req.columns).fill(1);
@@ -28,7 +27,7 @@
       console.log('You need to provide a width when using a non even column ratio');
       return;
     }
-
+    
     if(!req.rowRatio !== this.EVEN && req.height === 'undefined') {
       console.log('You need to provide a height when using a non even row ratio');
       return;
@@ -49,7 +48,7 @@
       req.gutterWidth = req.gutter;
       req.gutterHeight = req.gutter;
     }
-
+    
     // if width is set, override moduleWidth
     if(typeof req.width !== 'undefined') {
       req.moduleWidth = (req.width - ((req.columns-1) * req.gutterWidth)) / req.columns;
@@ -68,23 +67,20 @@
     this.calculateGrid()
   }
 
-  EasyGrid.prototype.calculateGrid = function() {
+  calculateGrid() {
     this.modules = [];
     // normalize the ratios
-    var totalColumnRatio = this.state.columnRatio.reduce((acc, cur) => acc + cur);
-    var totalRowRatio = this.state.rowRatio.reduce((acc, cur) => acc + cur);
+    const totalColumnRatio = this.state.columnRatio.reduce((acc, cur) => acc + cur);
+    const totalRowRatio = this.state.rowRatio.reduce((acc, cur) => acc + cur);
     this.normalizedColumnRatio = this.state.columnRatio.map((item) => item / totalColumnRatio);
     this.normalizedRowRatio = this.state.rowRatio.map((item) => item / totalRowRatio);
 
-    var totalHeight = 0;
-
-    for(var y = 0; y < this.state.rows; y++) {
-      var height = (this.state.height - ((this.state.rows-1) * this.state.gutterHeight)) * this.normalizedRowRatio[y];
-      var totalWidth = 0;
-      for(var x = 0; x < this.state.columns; x++) {
-        var width = (this.state.width - ((this.state.columns-1) * this.state.gutterWidth)) * this.normalizedColumnRatio[x];
-        
-
+    let totalHeight = 0;
+    for(let y = 0; y < this.state.rows; y++) {
+      const height = (this.state.height - ((this.state.rows-1) * this.state.gutterHeight)) * this.normalizedRowRatio[y];
+      let totalWidth = 0;
+      for(let x = 0; x < this.state.columns; x++) {
+        const width = (this.state.width - ((this.state.columns-1) * this.state.gutterWidth)) * this.normalizedColumnRatio[x];
         this.modules.push({
           x: this.state.x + totalWidth + (x * this.state.gutterWidth),
           y: this.state.y + totalHeight + (y * this.state.gutterHeight),
@@ -98,8 +94,8 @@
     }
   }
 
-  EasyGrid.prototype.getModule = function(column, row){
-    var index = (column-1) + ((row-1) * this.state.columns)
+  getModule(column, row) {
+    const index = (column-1) + ((row-1) * this.state.columns)
     if(this.modules[index]) {
       return this.modules[index]
     }
@@ -108,15 +104,13 @@
     }
   }
 
-  // Convenience Functions to get Colspans, Rowspans and Modulespans
-  EasyGrid.prototype.colSpan = function(from, to) {
-    var startCol = this.getModule(from, 1),
-        endCol = this.getModule(to, 1),
-        delta = to - from,
-        x = startCol.x,
-        y = startCol.y,
-        w = endCol.x + endCol.width - startCol.x,
-        h = this.state.height;
+  colSpan(from, to) {
+    const startCol = this.getModule(from, 1),
+          endCol = this.getModule(to, 1),
+          x = startCol.x,
+          y = startCol.y,
+          w = endCol.x + endCol.width - startCol.x,
+          h = this.state.height;
 
     return {
       x: x,
@@ -126,14 +120,13 @@
     };
   }
 
-  EasyGrid.prototype.rowSpan = function(from, to) {
-    var startRow = this.getModule(1, from),
-        endRow = this.getModule(1, to),
-        delta = to - from,
-        x = startRow.x,
-        y = startRow.y,
-        w = this.state.width,
-        h = endRow.y + endRow.height - startRow.y;
+  rowSpan(from, to) {
+    const startRow = this.getModule(1, from),
+          endRow = this.getModule(1, to),
+          x = startRow.x,
+          y = startRow.y,
+          w = this.state.width,
+          h = endRow.y + endRow.height - startRow.y;
 
     return {
       x: x,
@@ -143,9 +136,9 @@
     };
   }
 
-  EasyGrid.prototype.moduleSpan = function(fromCol, fromRow, toCol, toRow) {
-    var col = this.colSpan(fromCol, toCol);
-    var row = this.rowSpan(fromRow, toRow);
+  moduleSpan(fromCol, fromRow, toCol, toRow) {
+    const col = this.colSpan(fromCol, toCol);
+    const row = this.rowSpan(fromRow, toRow);
 
     return {
       x: col.x,
@@ -154,14 +147,6 @@
       height: row.height
     };
   }
+}
 
-  // Export for Node.js
-  if(typeof module !== 'undefined' && module.exports) {
-    module.exports = EasyGrid;
-  }
-  // Export for browser
-  else {
-    this.EasyGrid = EasyGrid;
-  }
-
-}.call(this));
+export default EasyGrid;

--- a/index.js
+++ b/index.js
@@ -59,6 +59,51 @@
     }
   }
 
+  // Convenience Functions to get Colspans, Rowspans and Modulespans
+  EasyGrid.prototype.colSpan = function(from, to) {
+    var startCol = this.getModule(from, 1),
+        delta = to - from,
+        x = startCol.x,
+        y = startCol.y,
+        w = this.state.moduleWidth + (delta * (this.state.moduleWidth + this.state.gutter)),
+        h = this.state.height;
+
+    return {
+      x: x,
+      y: y,
+      width: w,
+      height: h,
+    };
+  }
+
+  EasyGrid.prototype.rowSpan = function(from, to) {
+    var startRow = this.getModule(1, from),
+        delta = to - from,
+        x = startRow.x,
+        y = startRow.y,
+        w = this.state.width,
+        h = this.state.moduleHeight + (delta * (this.state.moduleHeight + this.state.gutter));
+
+    return {
+      x: x,
+      y: y,
+      width: w,
+      height: h,
+    };
+  }
+
+  EasyGrid.prototype.moduleSpan = function(fromCol, fromRow, toCol, toRow) {
+    var col = this.colSpan(fromCol, toCol);
+    var row = this.rowSpan(fromRow, toRow);
+
+    return {
+      x: col.x,
+      y: row.y,
+      width: col.width,
+      height: row.height
+    };
+  }
+
   // Export for Node.js
   if(typeof module !== 'undefined' && module.exports) {
     module.exports = EasyGrid;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "easygrid",
   "version": "1.0.0",
   "description": "A JavaScript library for easily calculating grid system positions in memory",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git://github.com/runemadsen/easygrid"

--- a/spec/EasyGridSpec.js
+++ b/spec/EasyGridSpec.js
@@ -30,4 +30,28 @@ describe("EasyGrid", function() {
     expect(myModule.height).toEqual(245);
   });
 
+  it("should give back a correct colspan", function() {
+    var col = grid.colSpan(2, 5);
+    expect(col.x).toEqual(61);
+    expect(col.y).toEqual(10);
+    expect(col.width).toEqual(194);
+    expect(col.height).toEqual(500);
+  });
+
+  it("should give back a correct rowspan", function() {
+    var row = grid.rowSpan(1, 2);
+    expect(row.x).toEqual(10);
+    expect(row.y).toEqual(10);
+    expect(row.width).toEqual(500);
+    expect(row.height).toEqual(500);
+  });
+
+  it("should give back a correct module size", function() {
+    var module = grid.moduleSpan(2, 1, 5, 2);
+    expect(module.x).toEqual(61);
+    expect(module.y).toEqual(10);
+    expect(module.width).toEqual(194);
+    expect(module.height).toEqual(500);
+  });
+
 });


### PR DESCRIPTION
Allows to build non-even grids where not all colums (or rows) have the same size. When building non-even grids, a ratio array can be passed to EasyGrid. Useful for kinetic typography. 😎 